### PR TITLE
HighFive integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: "Install libraries"
-      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev libfmt-dev catch2-dev spdlog-dev
+      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev
 
     - name: Build HighFive
       run: |
@@ -30,7 +30,7 @@ jobs:
           -DHIGHFIVE_UNIT_TESTS:BOOL=False \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-          -DHIGHFIVE_USE_EIGEN:BOOL=TRUE)
+          -DHIGHFIVE_USE_EIGEN:BOOL=True)
         source $GITHUB_WORKSPACE/ci/build.sh
     - name: Build and Test MorphIO
       run: |
@@ -38,15 +38,19 @@ jobs:
         cd MorphIO
         CMAKE_OPTIONS=(-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-          -DEXTERNAL_HIGHFIVE=True)
+          -DEXTERNAL_HIGHFIVE:BOOL=True)
         source $GITHUB_WORKSPACE/ci/build.sh
         ctest
     - name: Build and Test libsonata
       run: |
         git clone https://github.com/BlueBrain/libsonata.git --recursive
         cd libsonata
+        cd extlib/HighFive
+        git fetch && git checkout origin/master
+        cd ../..
         CMAKE_OPTIONS=(-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR)
+          -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+          -DEXTLIB_FROM_SUBMODULES:BOOL=True)
         source $GITHUB_WORKSPACE/ci/build.sh
         ctest
     - name: live debug session on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: "Install libraries"
-      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev libfmt-dev
+      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev libfmt-dev catch2-dev spdlog-dev
 
     - name: Build HighFive
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,49 @@
+name: HighFive_Integration_tests
+
+on:
+  push:
+    branches:
+      - ci_test
+  schedule:
+    - cron: '5 3 * * *'
+
+env:
+  BUILD_TYPE: RelWithDebInfo
+  INSTALL_DIR: ${{github.workspace}}/install
+
+jobs:
+
+  MorphIO:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: "Install libraries"
+      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev
+
+    - name: Build HighFive
+      working-directory: ${{github.workspace}}/build
+      run: |
+        git clone https://github.com/BlueBrain/HighFive.git --recursive
+        cd HighFive
+        mkdir build && cd build
+        CMAKE_OPTIONS=(-DHIGHFIVE_EXAMPLES:BOOL=False \
+          -DHIGHFIVE_UNIT_TESTS:BOOL=False \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+          -DHIGHFIVE_USE_EIGEN:BOOL=TRUE)
+        [ "$CC" ] && $CC --version
+        cmake --version
+        set -x
+        cmake .. "${CMAKE_OPTIONS[@]}"
+        make install
+    - name: Build and Test MorphIO
+      working-directory: ${{github.workspace}}/build
+      run: |
+        git clone https://github.com/BlueBrain/MorphIO.git --recursive
+        cd MorphIO
+        mkdir build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DEXTERNAL_HIGHFIVE=True
+        cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
+        ctest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,3 +47,6 @@ jobs:
         cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DEXTERNAL_HIGHFIVE=True
         cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
         ctest
+    - name: live debug session on failure
+      if: failure() && contains(github.event.head_commit.message, 'live-debug-ci')
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,38 +20,34 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: "Install libraries"
-      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev
+      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev libfmt-dev
 
     - name: Build HighFive
       run: |
         git clone https://github.com/BlueBrain/HighFive.git --recursive
         cd HighFive
-        mkdir build && cd build
         CMAKE_OPTIONS=(-DHIGHFIVE_EXAMPLES:BOOL=False \
           -DHIGHFIVE_UNIT_TESTS:BOOL=False \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DHIGHFIVE_USE_EIGEN:BOOL=TRUE)
-        [ "$CC" ] && $CC --version
-        set -x
-        cmake .. "${CMAKE_OPTIONS[@]}"
-        cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
-        cmake --install .
+        source $GITHUB_WORKSPACE/ci/build.sh
     - name: Build and Test MorphIO
       run: |
         git clone https://github.com/BlueBrain/MorphIO.git --recursive
         cd MorphIO
-        mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DEXTERNAL_HIGHFIVE=True
-        cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
+        CMAKE_OPTIONS=(-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+          -DEXTERNAL_HIGHFIVE=True)
+        source $GITHUB_WORKSPACE/ci/build.sh
         ctest
     - name: Build and Test libsonata
       run: |
         git clone https://github.com/BlueBrain/libsonata.git --recursive
         cd libsonata
-        mkdir build && cd build
-        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
-        cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
+        CMAKE_OPTIONS=(-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR)
+        source $GITHUB_WORKSPACE/ci/build.sh
         ctest
     - name: live debug session on failure
       if: failure() && contains(github.event.head_commit.message, 'live-debug-ci')

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,6 @@ jobs:
       run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev
 
     - name: Build HighFive
-      working-directory: ${{github.workspace}}/build
       run: |
         git clone https://github.com/BlueBrain/HighFive.git --recursive
         cd HighFive
@@ -34,12 +33,10 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DHIGHFIVE_USE_EIGEN:BOOL=TRUE)
         [ "$CC" ] && $CC --version
-        cmake --version
         set -x
         cmake .. "${CMAKE_OPTIONS[@]}"
         make install
     - name: Build and Test MorphIO
-      working-directory: ${{github.workspace}}/build
       run: |
         git clone https://github.com/BlueBrain/MorphIO.git --recursive
         cd MorphIO

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
 
-  MorphIO:
+  Integration:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,13 +35,22 @@ jobs:
         [ "$CC" ] && $CC --version
         set -x
         cmake .. "${CMAKE_OPTIONS[@]}"
-        make install
+        cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
+        cmake --install .
     - name: Build and Test MorphIO
       run: |
         git clone https://github.com/BlueBrain/MorphIO.git --recursive
         cd MorphIO
         mkdir build && cd build
         cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DEXTERNAL_HIGHFIVE=True
+        cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
+        ctest
+    - name: Build and Test libsonata
+      run: |
+        git clone https://github.com/BlueBrain/libsonata.git --recursive
+        cd libsonata
+        mkdir build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
         cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
         ctest
     - name: live debug session on failure

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,7 @@ on:
       - ci_test
   schedule:
     - cron: '5 3 * * *'
+  repository_dispatch:
 
 env:
   BUILD_TYPE: RelWithDebInfo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # HighFive-testing
-HighFive testing
+
+HighFive integration tests against BlueBrain projects. This is a CI-only repository allowing us to
+test HighFive against other BlueBrain projects without tying these tests directly into the library.
+
+Tests are triggered nightly and whenever a PR is merged on HighFive. The tests ensure that no
+functional regression is introduced into HighFive that would break downstream BlueBrain projects
+without directly impacting HighFive development. If an issue is detected we can go back and address
+it in HighFive.

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -x
+
+cmake -E make_directory build
+cd build
+cmake .. "${CMAKE_OPTIONS[@]}"
+cmake --build . --config $BUILD_TYPE --parallel 2 --verbose
+cmake --install .
+


### PR DESCRIPTION
Setup integration tests for highfive with MorphIO and libsonata.
The tests should run on a nightly schedule and with a webhook trigger when a PR in highfive is merged.