### PR TITLE
Run 'ctest' from inside 'build'.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,7 +53,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DEXTERNAL_HIGHFIVE:BOOL=True)
         source $GITHUB_WORKSPACE/ci/build.sh
-        ctest
+        cd build && ctest --output-on-failure
     - name: Build and Test libsonata
       if: success() || failure()
       run: |
@@ -66,7 +66,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DEXTLIB_FROM_SUBMODULES:BOOL=True)
         source $GITHUB_WORKSPACE/ci/build.sh
-        cd build && ctest
+        cd build && ctest --output-on-failure
     - name: live debug session on failure
       if: failure() && contains(github.event.head_commit.message, 'live-debug-ci')
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,7 +66,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
           -DEXTLIB_FROM_SUBMODULES:BOOL=True)
         source $GITHUB_WORKSPACE/ci/build.sh
-        ctest
+        cd build && ctest
     - name: live debug session on failure
       if: failure() && contains(github.event.head_commit.message, 'live-debug-ci')
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
We recently discovered that the unit-test of libsonata aren't run. See,
https://github.com/BlueBrain/HighFive-testing/actions/runs/4170132930/jobs/7218798117#step:6:191

Which reads:
```
+ ctest
*********************************
No test configuration file found!
*********************************
```

 This PR will try to fix the issue.